### PR TITLE
Proposal to shorten the technical test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Hint_: we're looking for a high-quality submission with great application archi
 
 * Render the list of stores from the stores.json file in alphabetical order through a backend template
 * Use postcodes.io to get the latitude and longitude for each postcode and render them next to each store location in the template
-* Build the functionality that allows you to return a list of stores in any given radius of any given postcode in the UK ordered from north to south and unit test it
+* Build the functionality that allows you to return a list of stores in any given radius of any given postcode in the UK ordered from north to south and unit test it - no need to render anything
 
 ### If you're applying for a full stack role
 

--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ _Hint_: we're looking for a high-quality submission with great application archi
 ### First
 
 * Create a new Python-based application (any framework is fine, we prefer Flask)
-* Build an API that returns stores from the `stores.json` file, based on a given search string in a performant way and unit test it, i.e. return "Newhaven" when searching for "hav" - make sure the search allows to use both city name and postcode
-* Order the results by matching postcode first and then matching city names, i.e. "br" would have "Orpington" as the 1st result (as its postcode is "BR5 3RP"), "Bracknell" as the 2nd
-
 
 ### If you're applying for a backend role
 
-* Use postcodes.io to get the latitude and longitude for each postcode and return them in an appropriate way as part of the API response
+* Render the list of stores from the stores.json file in alphabetical order through a backend template
+* Use postcodes.io to get the latitude and longitude for each postcode and render them next to each store location in the template
 * Build the functionality that allows you to return a list of stores in any given radius of any given postcode in the UK ordered from north to south and unit test it
 
 ### If you're applying for a full stack role
 
-* Using your favourite front-end framework (we'd prefer Vue, React or Ember though) on the user-facing side
+* Build an API that returns stores from the `stores.json` file, based on a given search string and unit test it, i.e. return "Newhaven" when searching for "hav" - make sure the search allows to use both city name and postcode
+* Order the results by matching postcode first and then matching city names, i.e. "br" would have "Orpington" as the 1st result (as its postcode is "BR5 3RP"), and then "Bracknell", "Broadstairs", "Tunbridge_Wells", and "Brentford"
+* Using your favourite frontend framework (we'd prefer Vue) on the user-facing side
 * Build a frontend that renders a text field for the query and the list of stores that match it
 * Add suggestions to the query field as you type, with a debounce effect of 100ms and a minimum of 2 characters
-* Limit the results to 3 and lazy load the rest
+* Limit the results to 3 and lazy load the rest on page scroll
 
 ### Finally
 


### PR DESCRIPTION
The recent changes to the technical test meant that backend and frontend applicants would complete part of the same test. This helped test markers.

However, these changes increased the time required to complete the backend test which was already quite long. A large number of the tests that came in before these changes are not complete and the reason given is always _time_.

We state that the test should be completable in 90-120minutes but with the recent changes this is not achievable. In an ideal world, candidates would feel comfortable to stop at 120minutes and submit what they have finished but candidates rarely do so. This puts those with less free time at a disadvantage.

One of the first candidates (a senior) to take the new version of the test found the test to be too long and spent ~4.5hours on it.

This PR proposes that we reverse the recent changes until we can conjoin the tests while reducing the time required to complete all features.

## Smaller changes

We should remove `in a performant way` from the store search. I spoke with a few engineers and none of us were sure how to mark this. Candidates have also found this to be confusing.

We should add "Broadstairs", "Tunbridge_Wells", "Brentford" to the search specification so that it is complete. Currently it's confusing as we suggest that only two stores should be returned for `br`. This is based off candidate feedback.

We should clarify what we mean by lazy load. A suggestion-search is normally used so that users do not need to scroll as they can keep typing to be more specific with their search. Myself and a few other engineers found this to be confusing. Adding `on page scroll` should cover it.

We should say that we prefer Vue.js but not name any other frameworks. I don't want candidates to feel like they have to choose one of three.